### PR TITLE
Enhance chat components

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ npm run build
 ```sh
 npm run lint
 ```
+
+## Chat Features
+
+Messages support **Markdown** and **Mermaid** diagram rendering. Each message can
+be copied and the full conversation can be exported as a JSON file from the
+header.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
   "dependencies": {
     "pinia": "^3.0.1",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0"
+    "vue-router": "^4.5.0",
+    "markdown-it": "^14.0.0",
+    "mermaid": "^10.4.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,12 +1,29 @@
 <template>
   <header class="header">
     <h1>DaoChat</h1>
-    <RouterLink to="/settings">Settings</RouterLink>
+    <div class="actions">
+      <button @click="exportChat">Export</button>
+      <RouterLink to="/settings">Settings</RouterLink>
+    </div>
   </header>
 </template>
 
 <script setup>
-import { RouterLink } from 'vue-router'
+import { RouterLink } from "vue-router";
+import { useChatStore } from "../stores/chat";
+
+const chat = useChatStore();
+
+function exportChat() {
+  const data = JSON.stringify(chat.messages, null, 2);
+  const blob = new Blob([data], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "chat-export.json";
+  a.click();
+  URL.revokeObjectURL(url);
+}
 </script>
 
 <style scoped>
@@ -15,5 +32,13 @@ import { RouterLink } from 'vue-router'
   justify-content: space-between;
   padding: 0.5rem 1rem;
   border-bottom: 1px solid #ccc;
+}
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+.actions button {
+  padding: 0.25rem 0.5rem;
 }
 </style>

--- a/src/components/ChatMessage.vue
+++ b/src/components/ChatMessage.vue
@@ -1,14 +1,44 @@
 <template>
   <div :class="['message', from]">
-    <div class="bubble">{{ text }}</div>
+    <div class="bubble">
+      <div ref="container" v-html="html" />
+      <button class="copy" @click="copyMessage">Copy</button>
+    </div>
   </div>
 </template>
 
 <script setup>
+import { computed, onMounted, watch, ref, nextTick } from "vue";
+import MarkdownIt from "markdown-it";
+import mermaid from "mermaid";
+
 const props = defineProps({
   from: String,
   text: String,
-})
+});
+
+const container = ref(null);
+const md = new MarkdownIt({ html: true, linkify: true });
+
+const html = computed(() => md.render(props.text));
+
+function renderMermaid() {
+  nextTick(() => {
+    if (container.value) {
+      mermaid.init(
+        undefined,
+        container.value.querySelectorAll(".language-mermaid"),
+      );
+    }
+  });
+}
+
+function copyMessage() {
+  navigator.clipboard.writeText(props.text);
+}
+
+onMounted(renderMermaid);
+watch(() => props.text, renderMermaid);
 </script>
 
 <style scoped>
@@ -27,5 +57,14 @@ const props = defineProps({
 }
 .message.user .bubble {
   background-color: #cce8ff;
+}
+
+.copy {
+  margin-top: 0.5rem;
+  background: none;
+  border: 1px solid #ccc;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.75rem;
+  cursor: pointer;
 }
 </style>


### PR DESCRIPTION
## Summary
- render messages in markdown with mermaid support
- allow messages to be copied
- add export button to header
- document chat features
- add markdown-it and mermaid dependencies

## Testing
- `npm run format`
- `npm run lint` *(fails: run-s not found)*
- `npm run lint:eslint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_6840f82c38588326875d5591b4f1bf5c